### PR TITLE
feat: 공용 모달 컨테이너 컴포넌트 구현

### DIFF
--- a/components/modal/ModalContainer.module.scss
+++ b/components/modal/ModalContainer.module.scss
@@ -1,0 +1,17 @@
+.wrapper {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.7);
+  z-index: 3;
+}
+
+.container {
+  background-color: $white;
+  border-radius: 0.8rem;
+}

--- a/components/modal/ModalContainer.tsx
+++ b/components/modal/ModalContainer.tsx
@@ -1,0 +1,29 @@
+import clsx from "clsx";
+import styles from "./ModalContainer.module.scss";
+import { Dispatch, SetStateAction, useRef } from "react";
+import { useOnClickOutside } from "usehooks-ts";
+
+interface ModalContainerProps {
+  setIsOpen: Dispatch<SetStateAction<boolean>>;
+  children: React.ReactNode;
+}
+
+function ModalContainer({ setIsOpen, children }: ModalContainerProps) {
+  const modalRef = useRef(null);
+
+  const handleClickOutside = () => {
+    setIsOpen(false);
+  };
+
+  useOnClickOutside(modalRef, handleClickOutside);
+
+  return (
+    <div className={clsx(styles.wrapper)}>
+      <div ref={modalRef} className={clsx(styles.container)}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export default ModalContainer;

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,4 @@
+declare module "*.module.scss" {
+  const content: { [className: string]: string };
+  export = content;
+}


### PR DESCRIPTION
## 작업 내용

### 최상위 폴더에 global.d.ts 선언

- scss 모듈 타입 선언
- 타입스크립트가 scss 파일 모듈을 못불러오는 오류 해결

### 공통 모달 컨테이너 구현

- 모달을 감싸는 백그라운드와 흰색 컨테이너 까지만 구현
- 모달 내부 컨텐츠는 사용하는 곳에서 children으로 넣어줘야 함
- 모달 배경 클릭하면 꺼지는 기능 usehooks 사용해서 구현

## 사용 예시

```
import ModalContainer from "@/components/modal/ModalContainer";

export default function Home() {
  const [isOpen, setIsOpen] = useState(false);

  return (
    <div>
      {isOpen && (
        <ModalContainer setIsOpen={setIsOpen}>
          모달창 내부 컨텐츠
        </ModalContainer>
      )}
    </div>
  );
}

```