### PR TITLE
[공용 컴포넌트] 플러스 아이콘만 있는 버튼 기능 추가 & text stlye 추가

### DIFF
--- a/components/button/PlusBtn/PlusBtn.module.scss
+++ b/components/button/PlusBtn/PlusBtn.module.scss
@@ -2,40 +2,67 @@
   border-radius: 8px;
   border: 1px solid #d9d9d9;
   background: $white;
-  padding: 2.4rem 9.9rem;
+  width: 33.2rem;
+  height: 7rem;
+  color: $black-200;
+  text-align: center;
+  @include text-style-16-bold();
 
   .btn-contents {
     display: flex;
     gap: 1.2rem;
     justify-content: center;
-
-    .btn-text {
-      color: #333236;
-      text-align: center;
-      font-family: Pretendard;
-      font-size: 16px;
-      font-style: normal;
-      font-weight: 600;
-      line-height: normal;
-    }
   }
 }
 
 .btn-size {
+  //새로운 대시보드 버튼 피그마 순서대로
   &-middle {
-    padding: 2.3rem 5.6rem;
+    width: 24.7rem;
+    height: 6.8rem;
   }
   &-small {
-    padding: 1.9rem 7rem;
+    width: 26rem;
+    height: 5.8rem;
   }
   //새로운 컬럼 추가하기 버튼 피그마 순서대로
   &-colum1 {
-    padding: 2.4rem 8.5rem;
+    width: 35.4rem;
+    height: 7rem;
   }
   &-colum2 {
-    padding: 2.4rem 18rem;
+    width: 54.4rem;
+    height: 7rem;
   }
   &-colum3 {
-    padding: 2rem 6rem;
+    width: 28.4rem;
+    height: 6rem;
+  }
+  //플러스 아이콘만 있는 버튼 피그마 순서대로
+  &-plus1 {
+    width: 31.4rem;
+    height: 4rem;
+  }
+  &-plus2 {
+    width: 54.4rem;
+    height: 4rem;
+  }
+  &-plus3 {
+    width: 28.4rem;
+    height: 3.2rem;
+  }
+}
+
+.btn-text {
+  //새로운 컬럼 추가하기
+  &-colum16 {
+    @include  text-style-16-colum();
+  }
+  &-colum18 {
+    @include  text-style-18-bold();
+  }
+  //새로운 대시보드
+  &-dsah14 {
+    @include  text-style-14-bold();
   }
 }

--- a/components/button/PlusBtn/PlusBtn.tsx
+++ b/components/button/PlusBtn/PlusBtn.tsx
@@ -4,28 +4,33 @@ import Image from "next/image";
 import styles from "./PlusBtn.module.scss";
 
 interface PlusBtnProps {
-  children: React.ReactNode;
+  children?: React.ReactNode;
   type?: "button";
   size?: string;
+  textStyle?: string;
 }
 
 const PlusBtn: React.FC<PlusBtnProps> = ({
   children,
   type = "button",
   size,
+  textStyle,
 
   ...props
 }) => {
   const plusBtnProps = { type, ...props };
 
-  const className = clsx(styles["btn"], size && styles[`btn-size-${size}`]);
+  const btnSize = clsx(styles["btn"], size && styles[`btn-size-${size}`]);
+  const textSize = clsx(textStyle && styles[`btn-text-${textStyle}`]);
 
   return (
-    <button className={className} {...plusBtnProps}>
+    <button className={btnSize} {...plusBtnProps}>
       <div className={clsx(styles["btn-contents"])}>
-        <div className={clsx(styles["btn-text"])}>
-          <span>{children}</span>
-        </div>
+        {children && (
+          <div className={textSize}>
+            <span>{children}</span>
+          </div>
+        )}
         <Image
           src="/button-icon/plus.png"
           alt="플러스 아이콘"

--- a/styles/mixins/_text-style.scss
+++ b/styles/mixins/_text-style.scss
@@ -48,6 +48,11 @@
   font-weight: 600;
   line-height: normal;
 }
+@mixin text-style-16-colum() {
+  font-size: $font-size-16;
+  font-weight: 700;
+  line-height: normal;
+}
 @mixin text-style-18-light() {
   font-size: $font-size-18;
   font-weight: 400;


### PR DESCRIPTION
기존 PlusBtn 컴포넌트에 플러스 아이콘만 있는 버튼 기능 추가 했습니다.

### 사용 예시
```
<PlusBtn size={'small'} textStyle={'dash14'} children={'새로운 대시보드'} />
```