### PR TITLE
[내 대시보드] 초대받은 대시보드 검색기능 추가

### DIFF
--- a/components/input/SearchBar.tsx
+++ b/components/input/SearchBar.tsx
@@ -1,16 +1,15 @@
-import { ChangeEventHandler, useState } from "react";
+import { ChangeEventHandler } from "react";
 import styles from "./SearchBar.module.scss";
 import Image from "next/image";
 
 const SEARCH_ICON_SIZE = 24;
 const SEARCH_ICON_PATH = "/icons/search.svg";
 
-const SearchBar = () => {
-  const [value, setValue] = useState("");
-  const handleInputChange: ChangeEventHandler<HTMLInputElement> = e => {
-    setValue(e.target.value);
-  };
+interface SearchBarProps {
+  onChange: ChangeEventHandler<HTMLInputElement>;
+}
 
+const SearchBar = ({ onChange }: SearchBarProps) => {
   return (
     <div className={styles.wrapper}>
       <Image
@@ -22,9 +21,8 @@ const SearchBar = () => {
       />
       <input
         type="text"
-        value={value}
         placeholder="검색"
-        onChange={handleInputChange}
+        onChange={onChange}
         className={styles.inputBox}
       />
     </div>

--- a/components/table/myInvitedDashboardTable/MyInvitedDashboardTable.module.scss
+++ b/components/table/myInvitedDashboardTable/MyInvitedDashboardTable.module.scss
@@ -13,15 +13,6 @@
   line-height: normal;
 }
 
-.noInvitation {
-  @include column-flexbox();
-  @include text-style-18-light();
-  width: 100%;
-  gap: 2.4rem;
-  color: $gray-400;
-  margin-top: 6.6rem;
-}
-
 .tableArea {
   margin-top: 20px;
   @include column-flexbox(start, stretch);

--- a/components/table/myInvitedDashboardTable/MyInvitedDashboardTable.tsx
+++ b/components/table/myInvitedDashboardTable/MyInvitedDashboardTable.tsx
@@ -1,29 +1,12 @@
-import Image from "next/image";
 import styles from "./MyInvitedDashboardTable.module.scss";
 import { MappedInvitations } from "@/types/invitations";
 import SearchBar from "@/components/input/SearchBar";
-
-const NO_INVITATION_ICON_SIZE = 100;
-const NO_INVITATION_ICON_PATH = "/icons/noInvitation.svg";
+import NoInvitation from "@/components/table/myInvitedDashboardTable/NoInvitation";
 
 interface MyInvitedDashboardTableProps {
   totalCount: number;
   invitations: MappedInvitations;
 }
-
-const NoInvitation = () => {
-  return (
-    <div className={styles.noInvitation}>
-      <Image
-        src={NO_INVITATION_ICON_PATH}
-        alt="No Invitation"
-        width={NO_INVITATION_ICON_SIZE}
-        height={NO_INVITATION_ICON_SIZE}
-      />
-      <span>아직 초대받은 대시보드가 없어요</span>
-    </div>
-  );
-};
 
 const MyInvitedDashboardTable = ({
   totalCount,

--- a/components/table/myInvitedDashboardTable/MyInvitedDashboardTable.tsx
+++ b/components/table/myInvitedDashboardTable/MyInvitedDashboardTable.tsx
@@ -2,6 +2,7 @@ import styles from "./MyInvitedDashboardTable.module.scss";
 import { MappedInvitations } from "@/types/invitations";
 import SearchBar from "@/components/input/SearchBar";
 import NoInvitation from "@/components/table/myInvitedDashboardTable/NoInvitation";
+import { ChangeEventHandler, useState } from "react";
 
 interface MyInvitedDashboardTableProps {
   totalCount: number;
@@ -10,14 +11,28 @@ interface MyInvitedDashboardTableProps {
 
 const MyInvitedDashboardTable = ({
   totalCount,
-  invitations,
+  invitations: initialInvitations,
 }: MyInvitedDashboardTableProps) => {
+  const [invitations, setInvitations] = useState(initialInvitations);
+
+  const handleInputChange: ChangeEventHandler<HTMLInputElement> = e => {
+    const input = e.target.value;
+
+    setInvitations(
+      initialInvitations.filter(
+        invitation =>
+          invitation.dashboard.includes(input) ||
+          invitation.inviter.includes(input),
+      ),
+    );
+  };
+
   return (
     <div className={styles.wrapper}>
       <div className={styles.title}>초대받은 대시보드</div>
       {totalCount ? (
         <div className={styles.tableArea}>
-          <SearchBar />
+          <SearchBar onChange={handleInputChange} />
           <table className={styles.table}>
             <thead>
               <tr>
@@ -29,7 +44,7 @@ const MyInvitedDashboardTable = ({
             <tbody>
               {invitations.map(invitation => (
                 /** @TODO 수락/거절 버튼 컴포넌트 완성되면 적용하기 */
-                <tr>
+                <tr key={invitation.id}>
                   <td>{invitation.dashboard}</td>
                   <td>{invitation.inviter}</td>
                   <td>{invitation.inviteAccepted ? "수락" : "거절"}</td>

--- a/components/table/myInvitedDashboardTable/NoInvitation.module.scss
+++ b/components/table/myInvitedDashboardTable/NoInvitation.module.scss
@@ -1,0 +1,8 @@
+.noInvitation {
+  @include column-flexbox();
+  @include text-style-18-light();
+  width: 100%;
+  gap: 2.4rem;
+  color: $gray-400;
+  margin-top: 6.6rem;
+}

--- a/components/table/myInvitedDashboardTable/NoInvitation.tsx
+++ b/components/table/myInvitedDashboardTable/NoInvitation.tsx
@@ -1,0 +1,21 @@
+import Image from "next/image";
+import styles from "./NoInvitation.module.scss";
+
+const NO_INVITATION_ICON_SIZE = 100;
+const NO_INVITATION_ICON_PATH = "/icons/noInvitation.svg";
+
+const NoInvitation = () => {
+  return (
+    <div className={styles.noInvitation}>
+      <Image
+        src={NO_INVITATION_ICON_PATH}
+        alt="No Invitation"
+        width={NO_INVITATION_ICON_SIZE}
+        height={NO_INVITATION_ICON_SIZE}
+      />
+      <span>아직 초대받은 대시보드가 없어요</span>
+    </div>
+  );
+};
+
+export default NoInvitation;

--- a/pages/mydashboard/mockInvitations.json
+++ b/pages/mydashboard/mockInvitations.json
@@ -14,7 +14,7 @@
         "id": 1
       },
       "invitee": {
-        "nickname": "test invitee",
+        "nickname": "invitee",
         "email": "invitee@test.com",
         "id": 1
       },
@@ -35,13 +35,34 @@
         "id": 2
       },
       "invitee": {
-        "nickname": "test invitee2",
-        "email": "invitee2@test.com",
-        "id": 2
+        "nickname": "invitee",
+        "email": "invitee@test.com",
+        "id": 1
       },
       "inviteAccepted": true,
       "createdAt": "2024-01-28T11:25:02.824Z",
       "updatedAt": "2024-01-28T11:25:02.824Z"
+    },
+    {
+      "id": 3,
+      "inviter": {
+        "nickname": "CheeseB",
+        "email": "cheeseball@naver.com",
+        "id": 3
+      },
+      "teamId": "3-3",
+      "dashboard": {
+        "title": "cheeseb's board",
+        "id": 3
+      },
+      "invitee": {
+        "nickname": "invitee",
+        "email": "invitee@test.com",
+        "id": 1
+      },
+      "inviteAccepted": false,
+      "createdAt": "2024-01-29T11:25:02.824Z",
+      "updatedAt": "2024-01-29T11:25:02.824Z"
     }
   ]
 }


### PR DESCRIPTION
## 작업내용

- MyInvitedDashboard 컴포넌트에 검색 기능 추가
- 대시보드 이름 + 초대자 이름으로 검색 적용
- api 명세로 보았을 때, 서버에 요청할때 검색 쿼리를 날리는 부분은 없었어서 컴포넌트 내에서 초기 데이터에 setState로 필터링만 적용함