### PR TITLE
[baseButton 컴포넌트] baseButton white, onClick prop 추가

### DIFF
--- a/components/button/baseButton/BaseButton.module.scss
+++ b/components/button/baseButton/BaseButton.module.scss
@@ -1,4 +1,4 @@
-.button-wrapper {
+.buttonWrapper {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -8,20 +8,22 @@
   &:disabled {
     background: $gray-400;
   }
+
+  &.white {
+    background-color: $white;
+    border: 0.1rem solid $gray-300;
+  }
 }
 
-.button-text {
-  color: white;
+.buttonText {
+  color: $white;
   @include text-style-18-middle();
   text-align: center;
-}
 
-.small {
-  font-size: 1.4rem;
-}
-
-.white {
-  background-color: $white;
-  color: $violet-200;
-  border: 0.1rem solid $gray-300;
+  &.small {
+    font-size: 1.4rem;
+  }
+  &.white {
+    color: $violet-200;
+  }
 }

--- a/components/button/baseButton/BaseButton.module.scss
+++ b/components/button/baseButton/BaseButton.module.scss
@@ -19,3 +19,9 @@
 .small {
   font-size: 1.4rem;
 }
+
+.white {
+  background-color: $white;
+  color: $violet-200;
+  border: 0.1rem solid $gray-300;
+}

--- a/components/button/baseButton/BaseButton.tsx
+++ b/components/button/baseButton/BaseButton.tsx
@@ -23,10 +23,13 @@ const Button: React.FC<ButtonProps> = ({
   const buttonProps = { type, disabled, ...props };
 
   return (
-    <button className={clsx(styles["button-wrapper"])} {...buttonProps}>
+    <button
+      className={clsx(styles.buttonWrapper, white && styles.white)}
+      {...buttonProps}
+    >
       <span
         className={clsx(
-          styles["button-text"],
+          styles.buttonText,
           small && styles.small,
           white && styles.white,
         )}

--- a/components/button/baseButton/BaseButton.tsx
+++ b/components/button/baseButton/BaseButton.tsx
@@ -7,6 +7,8 @@ interface ButtonProps {
   type?: "button" | "submit";
   disabled?: boolean;
   small?: boolean;
+  white?: boolean;
+  onClick?: () => void;
 }
 
 const Button: React.FC<ButtonProps> = ({
@@ -14,13 +16,22 @@ const Button: React.FC<ButtonProps> = ({
   type = "button",
   disabled = false,
   small = false,
+  white = false,
+  onClick,
   ...props
 }) => {
   const buttonProps = { type, disabled, ...props };
 
   return (
     <button className={clsx(styles["button-wrapper"])} {...buttonProps}>
-      <span className={clsx(styles["button-text"], small && styles.small)}>
+      <span
+        className={clsx(
+          styles["button-text"],
+          small && styles.small,
+          white && styles.white,
+        )}
+        onClick={onClick}
+      >
         {children}
       </span>
     </button>

--- a/components/table/inviteDashboardTable/InviteDashboardTable.module.scss
+++ b/components/table/inviteDashboardTable/InviteDashboardTable.module.scss
@@ -70,6 +70,11 @@
   .invitedEmail {
     @include text-style-16-light;
   }
+
+  Button {
+    width: 8.4rem;
+    height: 3.2rem;
+  }
 }
 
 .cancelButton {


### PR DESCRIPTION
### 변경 사항
- **white, onClick 조건 추가했습니다.**
   ![image](https://github.com/1cheol-and-team3-taskify/taskify/assets/148832727/b9de048b-662e-498d-b7cc-829bc03ac437)

### 적용 예시 
- **아래처럼 사용해주시면 됩니다, 버튼 크기는 Button 태그로 scss에서 직접 수정해주시면 됩니다!**
   ![image](https://github.com/1cheol-and-team3-taskify/taskify/assets/148832727/0fc6f4d3-e83c-4c9d-9978-9bfc49cad243)
   
<img width="650" alt="스크린샷 2024-01-31 16 57 37" src="https://github.com/1cheol-and-team3-taskify/taskify/assets/148832727/bf1eb5bd-0fcf-4999-a4f8-49608ea1499d">

